### PR TITLE
Add member operator== to basic_string_view class

### DIFF
--- a/util/string_view.h
+++ b/util/string_view.h
@@ -217,7 +217,12 @@ class basic_string_view
                    ? throw std::out_of_range{"index out of bounds"}
                    : basic_string_view{data() + pos, std::min(n, size() - pos)};
     }
-
+    
+    constexpr bool operator==(const basic_string_view& rhs) const noexcept
+    {
+        return this->compare(rhs)==0;
+    }
+    
     int compare(basic_string_view s) const noexcept
     {
         auto cmp


### PR DESCRIPTION
When used string_view in std::unordered_map (porter2_stemmer.cpp#L453)
compiler MSVC2015 is not able to disambiguate which operator== to call
among a lot of them: std::bernoulli_distribution, std::error_condition,
std::error_code,...
